### PR TITLE
fix: change package name in bsconfig.json to bs-guid

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "bs-uuid",
+  "name": "bs-guid",
   "refmt": 3,
   "bsc-flags": [
     "-bs-super-errors",


### PR DESCRIPTION
This fixes errors caused by BuckleScript expecting the path to the JS files to be `bs-uuid/src/Uuid.js`.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a fix for the code generated by BuckleScript due to a mismatch between the NPM module name and the `bsconfig.json` package name. AFAIK, there is no way to test it from within the module.

* **What is the current behavior?** (You can also link to an open issue here)
Building a project that uses these bindings results in broken code generated by BS, where the bindings are searched for in `bs-uuid/src/Uuid.js` instead of `bs-guid/src/Uuid.js`.

* **What is the new behavior (if this is a feature change)?**
It just works :-)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
None.